### PR TITLE
Require single colons for pseudo-element rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ common at GDS) however the CSS rules can be used alone.
 To add this to your project, install stylelint and this module:
 
 ```bash
-npm install --save-dev stylelint styelint-config-gds@0.1.0-pre.1
+npm install --save-dev stylelint styelint-config-gds@0.1.0-pre.2
 ```
 
 You then need to [configure](https://stylelint.io/user-guide/configure)

--- a/css.js
+++ b/css.js
@@ -104,6 +104,12 @@ module.exports = {
         ignore: ['attribute']
       }
     ],
+    // Require single colons for defining pseudo-elements
+    // IE8 and below do not support the modern double colon approach. Although
+    // few projects support IE8, we'd prefer to not exclude compatibility for
+    // purely syntactic reasons.
+    // https://stylelint.io/user-guide/rules/selector-pseudo-element-colon-notation
+    'selector-pseudo-element-colon-notation': 'single',
     // Disallow redundant properties in rules (for example: margin: 1px 1px 1px;)
     // https://stylelint.io/user-guide/rules/shorthand-property-no-redundant-values
     // Originates from: https://github.com/alphagov/govuk-frontend/blob/e248b4027102b2684f592a0501630075bdfa1fab/config/.sass-lint.yml#L436

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-config-gds",
-  "version": "0.1.0-pre.1",
+  "version": "0.1.0-pre.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-config-gds",
-  "version": "0.1.0-pre.1",
+  "version": "0.1.0-pre.2",
   "description": "A work-in-progress Stylelint configuration for the UK Government Digital Service.",
   "main": "scss.js",
   "scripts": {
@@ -8,7 +8,10 @@
     "test": "jest",
     "lint": "standard"
   },
-  "files": ["scss.js", "css.js"],
+  "files": [
+    "scss.js",
+    "css.js"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/alphagov/stylelint-config-gds.git"


### PR DESCRIPTION
This is changed is prompted from a [discussion in govuk_publishing_components](https://github.com/alphagov/govuk_publishing_components/pull/1611#discussion_r456497712) where the consensus was that we should maintain the single colon approach to pseudo-elements for IE8 compatibility. The logic for this was that, while we may not support IE8, syntax wasn't a sufficient reason to risk visual problems.

Presumably this can be removed once we reach a point of deeming IE8 insignificant enough to no longer worry about or if auto-prefixer is ubiquitous (which can convert from double to single automatically in compilation in IE8).