### PR TITLE
Add declaration-no-important

### DIFF
--- a/css.js
+++ b/css.js
@@ -31,6 +31,9 @@ module.exports = {
     // It's common for us to break up groups of CSS with an empty line
     // https://stylelint.io/user-guide/rules/declaration-empty-line-before
     'declaration-empty-line-before': null,
+    // Disallow !important within declarations
+    // https://stylelint.io/user-guide/rules/declaration-no-important
+    'declaration-no-important': true,
     // Properties and values that are disallowed
     // https://stylelint.io/user-guide/rules/declaration-property-value-blacklist
     'declaration-property-value-blacklist': {


### PR DESCRIPTION
## What
Adds `declaration-no-important: true` to ruleset

## Why
We want stylelint to raise an error on an important. This feels like the sort of rule developers should have to disable themselves for a single declaration.