### PR TITLE
Language tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,18 +46,18 @@ Stylelint.
 
 To lint SCSS you can add the following property to your package.json:
 
-```
-  "stylelint": {
-    "extends": "stylelint-config-gds/scss"
-  }
+```json
+"stylelint": {
+  "extends": "stylelint-config-gds/scss"
+}
 ```
 
 To lint CSS add the following:
 
-```
-  "stylelint": {
-    "extends": "stylelint-config-gds/css"
-  }
+```json
+"stylelint": {
+  "extends": "stylelint-config-gds/css"
+}
 ```
 
 You should then be able to run a lint with

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GDS Stylelint Config
 
-This provides a [stylelint](https://stylelint.io/) configuration for linting
+This provides a [Stylelint](https://stylelint.io/) configuration for linting
 SCSS and CSS files as per the conventions of the [Government Digital Service
 (GDS)](https://www.gov.uk/government/organisations/government-digital-service).
 
@@ -35,14 +35,14 @@ considered whenever proposals are made to add to or amend the rules.
 These rules are expected to be mostly used for SCSS projects (as these are more
 common at GDS) however the CSS rules can be used alone.
 
-To add this to your project, install stylelint and this module:
+To add this to your project, install Stylelint and this module:
 
 ```bash
 npm install --save-dev stylelint stylelint-config-gds
 ```
 
 You then need to [configure](https://stylelint.io/user-guide/configure)
-stylelint.
+Stylelint.
 
 To lint SCSS you can add the following property to your package.json:
 

--- a/css.js
+++ b/css.js
@@ -70,13 +70,13 @@ module.exports = {
     'no-descending-specificity': null,
     // Disallow prefixing decimals with a 0
     // https://stylelint.io/user-guide/rules/number-leading-zero
-    // Orginates from: https://github.com/alphagov/govuk-frontend/blob/e248b4027102b2684f592a0501630075bdfa1fab/config/.sass-lint.yml#L119
+    // Originates from: https://github.com/alphagov/govuk-frontend/blob/e248b4027102b2684f592a0501630075bdfa1fab/config/.sass-lint.yml#L119
     'number-leading-zero': 'never',
     // Require all class selectors to be in a hyphenated BEM format
     // https://stylelint.io/user-guide/rules/selector-class-pattern
     // Originates from: https://github.com/alphagov/govuk-frontend/blob/e248b4027102b2684f592a0501630075bdfa1fab/config/.sass-lint.yml#L39
     'selector-class-pattern': [
-      // a loose interpretation on hyphenathed BEM in order to allow BEM
+      // a loose interpretation on hyphenated BEM in order to allow BEM
       // style and govuk-! overrides
       /^[a-z]([a-z0-9-_!])*$/, {
         resolveNestedSelectors: true,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "stylelint-config-gds",
   "version": "0.1.0",
-  "description": "A stylelint configuration for the UK Government Digital Service.",
+  "description": "A Stylelint configuration for the UK Government Digital Service.",
   "main": "scss.js",
   "scripts": {
     "pretest": "npm run lint",


### PR DESCRIPTION
Selected language-related commits from #19:

* Fixes 2 typos in the CSS config, capitalises ‘Stylelint’ (as the project itself does) and adds language hints to some of the code examples in the README file to ensure they are highlighted correctly as JSON.