### PR TITLE
Add Dependabot config for npm and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+
+updates:
+  # Update npm packages
+  - package-ecosystem: npm
+    directory: /
+
+    # Bump package.json versions too
+    # in addition to security updates
+    allow:
+      - dependency-type: direct
+    versioning-strategy: increase

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,7 @@ updates:
     allow:
       - dependency-type: direct
     versioning-strategy: increase
+
+  # Update GitHub Actions
+  - package-ecosystem: github-actions
+    directory: /


### PR DESCRIPTION
Hope this is useful

Noticed the [last GitHub workflow run](https://github.com/alphagov/stylelint-config-gds/actions/runs/4819067901) for https://github.com/alphagov/stylelint-config-gds/pull/30 had a few warnings

Looks like Node.js 12 actions are either stopping or being forcefully (breaking?) updated soon:

**GitHub Actions: All Actions will begin running on Node16 instead of Node12**
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

This PR sets up Dependabot to update GitHub Actions such as:

* [`actions/setup-node@v2`](https://github.com/actions/setup-node/releases/tag/v2.5.2)
* [`actions/checkout@v2`](https://github.com/actions/checkout/releases/tag/v2.7.0)

But also npm packages such as [`stylelint`](https://www.npmjs.com/package/stylelint) and bundled configs [`stylelint-config-standard`](https://www.npmjs.com/package/stylelint-config-standard) etc