### PR TITLE
Configure Dependabot with daily check interval

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
   # Update npm packages
   - package-ecosystem: npm
     directory: /
+    schedule:
+      interval: daily
 
     # Bump package.json versions too
     # in addition to security updates
@@ -14,3 +16,5 @@ updates:
   # Update GitHub Actions
   - package-ecosystem: github-actions
     directory: /
+    schedule:
+      interval: daily


### PR DESCRIPTION
Looks like `schedule.interval` is a required field so this commit aligns the project with GOV.UK daily checks

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#scheduleinterval