### PR TITLE
Remove `selector-pseudo-element-colon-notation`

### DIFF
--- a/css-rules.js
+++ b/css-rules.js
@@ -151,12 +151,6 @@ module.exports = {
     // compatibility in older browsers
     // https://stylelint.io/user-guide/rules/selector-not-notation/
     'selector-not-notation': 'simple',
-    // Require single colons for defining pseudo-elements
-    // IE8 and below do not support the modern double colon approach. Although
-    // few projects support IE8, we'd prefer to not exclude compatibility for
-    // purely syntactic reasons.
-    // https://stylelint.io/user-guide/rules/list/selector-pseudo-element-colon-notation/
-    'selector-pseudo-element-colon-notation': 'single',
     // Disallow redundant properties in rules (for example: margin: 1px 1px 1px;)
     // https://stylelint.io/user-guide/rules/list/shorthand-property-no-redundant-values/
     // Originates from: https://github.com/alphagov/govuk-frontend/blob/e248b4027102b2684f592a0501630075bdfa1fab/config/.sass-lint.yml#L436


### PR DESCRIPTION
The Design System team is in the process of removing support for Internet Explorer 8, 9 and 10 from GOV.UK Frontend, signalling our intent to no longer support these browsers or provide fixes or polyfills specifically for them. 

Supporting IE8–10 has not been a requirement for services since June 2018.

We do not expect service teams to continue making accommodations for legacy IE versions now or in future and are encouraging them to begin removing any code specifically for these versions of IE.

As part of this, we should remove `selector-pseudo-element-colon-notation` to begin enforcing the default standards-compliant double-colon syntax instead.