### PR TITLE
Remove deprecated stylistic rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@
 
 ## Unreleased
 
+### Breaking change: Removal of stylistic rules
+
+We have removed all stylistic rules (such as tabs/spaces, indentation, etc) as they're no longer included in Stylelint common configurations as part of their [deprecation in Stylelint 15]((https://stylelint.io/migration-guide/to-15/#deprecated-stylistic-rules)).
+
+As per Stylelint's own documentation, we recommend that projects adopt [Prettier](https://prettier.io/) for formatting instead.
+
+If this is not possible for your project, you can [configure](https://stylelint.io/user-guide/configure/) your projects' Stylelint configuration to use the [`stylelint-stylistic`](https://github.com/elirasza/stylelint-stylistic) or [`stylelint-codeguide`](https://github.com/firefoxic/stylelint-codeguide) plugins to restore the deprecated rules instead.
+
+This change was made in [pull request #44: Remove deprecated stylistic rules](https://github.com/alphagov/stylelint-config-gds/pull/44).
+
 ### Removal of rule enforcing single-colon pseudo elements
 
 We removed the rule [`selector-pseudo-element-colon-notation`](https://stylelint.io/user-guide/rules/selector-pseudo-element-colon-notation/) preventing double-colon `::before` and `::after` pseudo elements.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+### Removal of rule enforcing single-colon pseudo elements
+
+We removed the rule [`selector-pseudo-element-colon-notation`](https://stylelint.io/user-guide/rules/selector-pseudo-element-colon-notation/) preventing double-colon `::before` and `::after` pseudo elements.
+
+Internet Explorer 8, 9 and 10 require single-colon `:before` and `:after` pseudo elements, but supporting these old browsers has not been a requirement for services since June 2018. If you wish to keep support you can [configure your Stylelint](https://stylelint.io/user-guide/configure/) to re-enable it.
+
+This change was made in [pull request #36: Remove `selector-pseudo-element-colon-notation`](https://github.com/alphagov/stylelint-config-gds/pull/36).
+
 ## 0.3.0
 
 This release updates all bundled configs to the maximum version supported by Stylelint 14. This work is in preparation for [Stylelint 15 deprecating all stylistic rules](https://stylelint.io/migration-guide/to-15/#deprecated-stylistic-rules) with a recommendation to use Prettier for formatting.

--- a/css-rules.js
+++ b/css-rules.js
@@ -8,72 +8,72 @@ module.exports = {
   rules: {
     // GDS predominantly uses a conventional to specify opacity values with
     // decimals
-    // https://stylelint.io/user-guide/rules/list/alpha-value-notation/
+    // https://stylelint.io/user-guide/rules/alpha-value-notation/
     'alpha-value-notation': 'number',
     // This rule is disabled because our house style has a lot of at-rules
     // via SCSS where new lines are used indiscriminately for readability.
-    // https://stylelint.io/user-guide/rules/list/at-rule-empty-line-before/
+    // https://stylelint.io/user-guide/rules/at-rule-empty-line-before/
     'at-rule-empty-line-before': null,
     // This rule expects autoprefixer to be used but we don't consistently use
     // that tool across GDS products.
-    // https://stylelint.io/user-guide/rules/list/at-rule-no-vendor-prefix/
+    // https://stylelint.io/user-guide/rules/at-rule-no-vendor-prefix/
     'at-rule-no-vendor-prefix': null,
     // Require commas to separate numbers in colour functions, this is
     // required for Internet Explorer support which doesn't understand the
     // modern syntax.
-    // https://stylelint.io/user-guide/rules/list/color-function-notation/
+    // https://stylelint.io/user-guide/rules/color-function-notation/
     'color-function-notation': 'legacy',
     // Disallow using CSS named colours
-    // https://stylelint.io/user-guide/rules/list/color-named/
+    // https://stylelint.io/user-guide/rules/color-named/
     // Originates from: https://github.com/alphagov/govuk-frontend/blob/e248b4027102b2684f592a0501630075bdfa1fab/config/.sass-lint.yml#L149
     'color-named': 'never',
     // Require 6 character hex definitions when 3 would work
-    // https://stylelint.io/user-guide/rules/list/color-hex-length/
+    // https://stylelint.io/user-guide/rules/color-hex-length/
     // Originates from: https://github.com/alphagov/govuk-frontend/blob/master/docs/contributing/coding-standards/css.md#colours-defined-as-variables-should-be-in-lowercase-and-in-full-length
     'color-hex-length': 'long',
     // Requires that if all longhand properties are used then shorthand must be
     // used (i.e. if all margin-top, margin-right, margin-bottom, margin-left
     // are used you must use margin).
-    // https://stylelint.io/user-guide/rules/list/declaration-block-no-redundant-longhand-properties/
+    // https://stylelint.io/user-guide/rules/declaration-block-no-redundant-longhand-properties/
     // This is disabled due to concerns that
     // it produces less readable code (see: https://github.com/alphagov/govuk-frontend/pull/2567)
     'declaration-block-no-redundant-longhand-properties': null,
     // Require all rules to be multiline
-    // https://stylelint.io/user-guide/rules/list/declaration-block-single-line-max-declarations/
+    // https://stylelint.io/user-guide/rules/declaration-block-single-line-max-declarations/
     // Originates from: https://github.com/alphagov/govuk-frontend/blob/e248b4027102b2684f592a0501630075bdfa1fab/config/.sass-lint.yml#L32
     'declaration-block-single-line-max-declarations': 0,
     // It's common for us to break up groups of CSS with an empty line
-    // https://stylelint.io/user-guide/rules/list/declaration-empty-line-before/
+    // https://stylelint.io/user-guide/rules/declaration-empty-line-before/
     'declaration-empty-line-before': null,
     // Disallow !important within declarations
-    // https://stylelint.io/user-guide/rules/list/declaration-no-important/
+    // https://stylelint.io/user-guide/rules/declaration-no-important/
     'declaration-no-important': true,
     // Properties and values that are disallowed
-    // https://stylelint.io/user-guide/rules/list/declaration-property-value-disallowed-list/
+    // https://stylelint.io/user-guide/rules/declaration-property-value-disallowed-list/
     'declaration-property-value-disallowed-list': {
       // Originates from: https://github.com/alphagov/govuk-frontend/blob/e248b4027102b2684f592a0501630075bdfa1fab/config/.sass-lint.yml#L222
       '/transition/': ['/all/']
     },
     // Disallow scheme relative URLs such as //www.gov.uk
-    // https://stylelint.io/user-guide/rules/list/function-url-no-scheme-relative?
+    // https://stylelint.io/user-guide/rules/function-url-no-scheme-relative?
     // Originates from: https://github.com/alphagov/govuk-frontend/blob/e248b4027102b2684f592a0501630075bdfa1fab/config/.sass-lint.yml#L230
     'function-url-no-scheme-relative': true,
     // Always require quotes in url function calls
-    // https://stylelint.io/user-guide/rules/list/function-url-quotes/
+    // https://stylelint.io/user-guide/rules/function-url-quotes/
     // Originates from: https://github.com/alphagov/govuk-frontend/blob/e248b4027102b2684f592a0501630075bdfa1fab/config/.sass-lint.yml#L430
     'function-url-quotes': 'always',
     // Disallow absolute URLs with scheme other than data, assets should be local
-    // https://stylelint.io/user-guide/rules/list/function-url-scheme-allowed-list/
+    // https://stylelint.io/user-guide/rules/function-url-scheme-allowed-list/
     // Originates from: https://github.com/alphagov/govuk-frontend/blob/e248b4027102b2684f592a0501630075bdfa1fab/config/.sass-lint.yml#L230
     'function-url-scheme-allowed-list': ['data'],
     // Traditionally GDS linters haven't had line length rules, which means
     // this would be inconsistent with JS linting and have a lot of churn
     // to apply
-    // https://stylelint.io/user-guide/rules/list/max-line-length/
+    // https://stylelint.io/user-guide/rules/max-line-length/
     'max-line-length': null,
     // Disallow deep nesting, ideally only exceptions (such as .js-enabled) should
     // have nesting
-    // https://stylelint.io/user-guide/rules/list/max-nesting-depth/
+    // https://stylelint.io/user-guide/rules/max-nesting-depth/
     // Originates from: https://github.com/alphagov/govuk-frontend/blob/e248b4027102b2684f592a0501630075bdfa1fab/config/.sass-lint.yml#L136
     'max-nesting-depth': [
       2, {
@@ -82,21 +82,21 @@ module.exports = {
     ],
     // This rule expects autoprefixer to be used but we don't consistently use
     // that tool across GDS products.
-    // https://stylelint.io/user-guide/rules/list/media-feature-name-no-vendor-prefix/
+    // https://stylelint.io/user-guide/rules/media-feature-name-no-vendor-prefix/
     'media-feature-name-no-vendor-prefix': null,
     // This rules attempts to prevent defining defining rules with a more
     // specific selector than a previous one, where they may override. This
     // is disables as it conflicts with our common usage of nesting rules
     // within a BEM modifier where a selector may be more or less specific
     // than a previous rule.
-    // https://stylelint.io/user-guide/rules/list/no-descending-specificity/
+    // https://stylelint.io/user-guide/rules/no-descending-specificity/
     'no-descending-specificity': null,
     // This rule expects autoprefixer to be used but we don't consistently use
     // that tool across GDS products.
-    // https://stylelint.io/user-guide/rules/list/property-no-vendor-prefix/
+    // https://stylelint.io/user-guide/rules/property-no-vendor-prefix/
     'property-no-vendor-prefix': null,
     // Require all class selectors to be in a hyphenated BEM format
-    // https://stylelint.io/user-guide/rules/list/selector-class-pattern/
+    // https://stylelint.io/user-guide/rules/selector-class-pattern/
     // Originates from: https://github.com/alphagov/govuk-frontend/blob/e248b4027102b2684f592a0501630075bdfa1fab/config/.sass-lint.yml#L39
     'selector-class-pattern': [
       // a loose interpretation on hyphenated BEM in order to allow BEM
@@ -108,7 +108,7 @@ module.exports = {
       }
     ],
     // Require any allowed id selectors to be in a hyphenated lowercase form
-    // https://stylelint.io/user-guide/rules/list/selector-id-pattern/
+    // https://stylelint.io/user-guide/rules/selector-id-pattern/
     // Originates from: https://github.com/alphagov/govuk-frontend/blob/e248b4027102b2684f592a0501630075bdfa1fab/config/.sass-lint.yml#L107
     'selector-id-pattern': [
       /^[a-z]([a-z0-9-])*$/, {
@@ -118,11 +118,11 @@ module.exports = {
       }
     ],
     // Disallow all ids in selectors
-    // https://stylelint.io/user-guide/rules/list/selector-max-id/
+    // https://stylelint.io/user-guide/rules/selector-max-id/
     // Originates from: https://github.com/alphagov/govuk-frontend/blob/e248b4027102b2684f592a0501630075bdfa1fab/config/.sass-lint.yml#L186
     'selector-max-id': 0,
     // Disallows qualifying a selector based on the element
-    // https://stylelint.io/user-guide/rules/list/selector-no-qualifying-type/
+    // https://stylelint.io/user-guide/rules/selector-no-qualifying-type/
     // Originates from: https://github.com/alphagov/govuk-frontend/blob/e248b4027102b2684f592a0501630075bdfa1fab/config/.sass-lint.yml#L206
     'selector-no-qualifying-type': [
       true, {
@@ -132,19 +132,19 @@ module.exports = {
     ],
     // This rule expects autoprefixer to be used but we don't consistently use
     // that tool across GDS products.
-    // https://stylelint.io/user-guide/rules/list/selector-no-vendor-prefix/
+    // https://stylelint.io/user-guide/rules/selector-no-vendor-prefix/
     'selector-no-vendor-prefix': null,
     // Disallow complex `:not()` notation (CSS Selectors Level 4) for backwards
     // compatibility in older browsers
     // https://stylelint.io/user-guide/rules/selector-not-notation/
     'selector-not-notation': 'simple',
     // Disallow redundant properties in rules (for example: margin: 1px 1px 1px;)
-    // https://stylelint.io/user-guide/rules/list/shorthand-property-no-redundant-values/
+    // https://stylelint.io/user-guide/rules/shorthand-property-no-redundant-values/
     // Originates from: https://github.com/alphagov/govuk-frontend/blob/e248b4027102b2684f592a0501630075bdfa1fab/config/.sass-lint.yml#L436
     'shorthand-property-no-redundant-values': true,
     // This rule expects autoprefixer to be used but we don't consistently use
     // that tool across GDS products.
-    // https://stylelint.io/user-guide/rules/list/value-no-vendor-prefix/
+    // https://stylelint.io/user-guide/rules/value-no-vendor-prefix/
     'value-no-vendor-prefix': null
   }
 }

--- a/css-rules.js
+++ b/css-rules.js
@@ -18,15 +18,6 @@ module.exports = {
     // that tool across GDS products.
     // https://stylelint.io/user-guide/rules/list/at-rule-no-vendor-prefix/
     'at-rule-no-vendor-prefix': null,
-    // Always require a newline after a closing brace of a rule
-    // https://stylelint.io/user-guide/rules/list/block-closing-brace-newline-after/
-    // Originates from: https://github.com/kristerkari/stylelint-scss/blob/f54d9861e35891312bda98afe2404a993a4262e0/docs/examples/if-else.md
-    'block-closing-brace-newline-after': [
-      'always', {
-        // Exceptions for conditionals, particularly useful for SCSS.
-        ignoreAtRules: ['if', 'else']
-      }
-    ],
     // Require commas to separate numbers in colour functions, this is
     // required for Internet Explorer support which doesn't understand the
     // modern syntax.
@@ -100,10 +91,6 @@ module.exports = {
     // than a previous rule.
     // https://stylelint.io/user-guide/rules/list/no-descending-specificity/
     'no-descending-specificity': null,
-    // Disallow prefixing decimals with a 0
-    // https://stylelint.io/user-guide/rules/list/number-leading-zero/
-    // Originates from: https://github.com/alphagov/govuk-frontend/blob/e248b4027102b2684f592a0501630075bdfa1fab/config/.sass-lint.yml#L119
-    'number-leading-zero': 'never',
     // This rule expects autoprefixer to be used but we don't consistently use
     // that tool across GDS products.
     // https://stylelint.io/user-guide/rules/list/property-no-vendor-prefix/

--- a/scss-rules.js
+++ b/scss-rules.js
@@ -22,7 +22,7 @@ module.exports = {
       }
     ],
     // Disallow @debug
-    // https://stylelint.io/user-guide/rules/list/at-rule-disallowed-list/
+    // https://stylelint.io/user-guide/rules/at-rule-disallowed-list/
     // Originates from: https://github.com/alphagov/govuk-frontend/blob/e248b4027102b2684f592a0501630075bdfa1fab/config/.sass-lint.yml#L166
     'at-rule-disallowed-list': ['debug'],
     // https://github.com/stylelint-scss/stylelint-scss/tree/master/src/rules/at-function-pattern
@@ -87,7 +87,7 @@ module.exports = {
     ],
     // Disable @import needing to be first declarations
     // @import has a different usage in SCSS to CSS and may be scoped or follow SCSS conditionals
-    // https://stylelint.io/user-guide/rules/list/no-invalid-position-at-import-rule/
+    // https://stylelint.io/user-guide/rules/no-invalid-position-at-import-rule/
     'no-invalid-position-at-import-rule': null
   }
 }


### PR DESCRIPTION
This PR removes all stylistic rules deprecated by Stylelint 15 and has been split out from:

* https://github.com/alphagov/stylelint-config-gds/pull/32

It also includes:

1. New CHANGELOG entry for deprecated stylistic rules removal
2. New CHANGELOG entry for https://github.com/alphagov/stylelint-config-gds/pull/36
3. Fixed broken links to Stylelint rule documentation

## Breaking change: Removal of stylistic rules

As per Stylelint's own documentation, we recommend that projects adopt [Prettier](https://prettier.io/) for formatting instead

If this is not possible for your project, you can [configure](https://stylelint.io/user-guide/configure/) your projects' Stylelint configuration to use the [`stylelint-stylistic`](https://github.com/elirasza/stylelint-stylistic) or [`stylelint-codeguide`](https://github.com/firefoxic/stylelint-codeguide) plugins to restore these rules.