### PR TITLE
Fix rule `media-feature-range-notation` to use `'prefix'` notation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+* [pull request #59: Fix rule `media-feature-range-notation` to use `'prefix'` notation](https://github.com/alphagov/stylelint-config-gds/pull/59)
+
 ## 1.1.0
 
 This release includes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 1.1.1
+
+This release includes:
 
 * [pull request #59: Fix rule `media-feature-range-notation` to use `'prefix'` notation](https://github.com/alphagov/stylelint-config-gds/pull/59)
 

--- a/css-rules.js
+++ b/css-rules.js
@@ -84,6 +84,11 @@ module.exports = {
     // that tool across GDS products.
     // https://stylelint.io/user-guide/rules/media-feature-name-no-vendor-prefix/
     'media-feature-name-no-vendor-prefix': null,
+    // Require media query feature ranges to use prefix notation, this is
+    // required for Internet Explorer support which doesn't understand the
+    // modern syntax.
+    // https://stylelint.io/user-guide/rules/media-feature-range-notation/
+    'media-feature-range-notation': 'prefix',
     // This rules attempts to prevent defining defining rules with a more
     // specific selector than a previous one, where they may override. This
     // is disables as it conflicts with our common usage of nesting rules


### PR DESCRIPTION
A previous update to Stylelint included the rule [`media-feature-range-notation`](https://stylelint.io/user-guide/rules/media-feature-range-notation/)

But similar [to other rules](https://github.com/alphagov/stylelint-config-gds/pull/30/commits/452249c3e4f400f607c65768cb8da4ca2d4c1ac4) it enforces syntax that is [incompatible with Internet Explorer](https://caniuse.com/css-media-range-syntax)

This PR changes the default to ~`context`~ `prefix` until [**Media Queries Level 4** range context](https://www.w3.org/TR/mediaqueries-4/#mq-range-context) is better supported

```patch
.govuk-footer__copyright-logo {
  background-image: govuk-image-url("govuk-crest.png");

- @media (resolution >= 2dppx) {
+ @media (min-resolution: 2dppx) {
    background-image: govuk-image-url("govuk-crest-2x.png");
  }
}
```

**Note:** [Autoprefixer only handles prefixes](https://github.com/postcss/autoprefixer/issues/304#issuecomment-53648510) but a [PostCSS plugin for `@media` range context](https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-media-minmax#readme) is available