### PR TITLE
Replace deprecated `set-output` with GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,10 @@ jobs:
       - name: Establish version
         run: |
           LOCAL=$(node -p "require('./package.json').version")
-          echo "::set-output name=local::${LOCAL}"
-          echo "::set-output name=remote::$(npm view stylelint-config-gds version)"
+          echo "local=${LOCAL}" >> $GITHUB_OUTPUT
+          echo "remote=$(npm view stylelint-config-gds version)" >> $GITHUB_OUTPUT
           if git ls-remote --tags --exit-code origin ${LOCAL}; then
-            echo "::set-output name=tagged::yes"
+            echo "tagged=yes" >> $GITHUB_OUTPUT
           fi
         id: version
       - name: Tag version


### PR DESCRIPTION
Addresses the following warning during releases:

>The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Removal was postponed from June 2023