### PR TITLE
Prepare release v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 2.0.0
 
 This release upgrades to Stylelint 16 and [removes rules deprecated in Stylelint 15](#breaking-change-removal-of-stylistic-rules)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stylelint-config-gds",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stylelint-config-gds",
-      "version": "1.1.1",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "stylelint-config-standard": "^36.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-config-gds",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "description": "A Stylelint configuration for the UK Government Digital Service.",
   "main": "scss.js",
   "scripts": {


### PR DESCRIPTION
Updates the CHANGELOG for v2.0.0 and applies `npm version major` without git tag

This will release our upgrade to Stylelint 16 including all bundled configs