### PR TITLE
Update Stylelint and config dependencies to version 17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,65 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+### Breaking change: Requires Stylelint 17 and [Node.js](http://Node.js) v20.19.0+
+
+This release upgrades Stylelint to version 17, which requires a minimum Node.js version of v20.19.0.
+
+If you use Stylelint JavaScript API, note that Stylelint 17 now only supports ES Modules and no longer supports CommonJS.
+
+Read about breaking changes in the Stylelint [Migrating to v17.0.0](https://stylelint.io/migration-guide/to-17/) guide.
+
+### Breaking change: New or re-configured Stylelint rules
+
+This release also upgrades the configuration packages used by stylelint-config-gds:
+
+- [stylelint-config-standard](https://github.com/stylelint/stylelint-config-standard/tree/40.0.0) to version 40.0.0 and the [stylelint-config-recommended](https://github.com/stylelint/stylelint-config-recommended/tree/18.0.0) it depends on to version 18.0.0  
+- [stylelint-config-standard-scss](https://github.com/stylelint-scss/stylelint-config-standard-scss/tree/v17.0.0) to version 17.0.0 and the [stylelint-config-recommended-scss](https://github.com/stylelint-scss/stylelint-config-recommended-scss/tree/v17.0.0) it depends on to version 17.0.0
+
+You may see new errors when linting from the following new rules:
+
+- [block-no-redundant-nested-style-rules](https://stylelint.io/user-guide/rules/block-no-redundant-nested-style-rules/)  
+- [color-function-alias-notation](https://stylelint.io/user-guide/rules/color-function-alias-notation/) (automatically fixable by running `stylelint --fix`)  
+- [container-name-pattern](https://stylelint.io/user-guide/rules/container-name-pattern/)   
+- [layer-name-pattern](https://stylelint.io/user-guide/rules/layer-name-pattern/)  
+- [media-type-no-deprecated](https://stylelint.io/user-guide/rules/media-type-no-deprecated/)  
+- [nesting-selector-no-missing-scoping-root](https://stylelint.io/user-guide/rules/nesting-selector-no-missing-scoping-root/)  
+- [no-invalid-position-declaration](https://stylelint.io/user-guide/rules/no-invalid-position-declaration/)  
+- [property-no-deprecated](https://stylelint.io/user-guide/rules/property-no-deprecated/)  
+- [syntax-string-no-invalid](https://stylelint.io/user-guide/rules/syntax-string-no-invalid/)  
+- [at-rule-descriptor-no-unknown](https://stylelint.io/user-guide/rules/at-rule-descriptor-no-unknown/)  
+- [at-rule-descriptor-value-no-unknown](https://stylelint.io/user-guide/rules/at-rule-descriptor-value-no-unknown/)  
+- [at-rule-no-deprecated](https://stylelint.io/user-guide/rules/at-rule-no-deprecated/)  
+- [declaration-property-value-keyword-no-deprecated](https://stylelint.io/user-guide/rules/declaration-property-value-keyword-no-deprecated/)  
+- [declaration-property-value-no-unknown](https://stylelint.io/user-guide/rules/declaration-property-value-no-unknown/)  
+- [media-feature-name-value-no-unknown](https://stylelint.io/user-guide/rules/media-feature-name-value-no-unknown/)
+
+You may also see new errors from the [string-no-newline](https://stylelint.io/user-guide/rules/string-no-newline/) rule, now configured with `{ ignore: ['at-rule-preludes', 'declaration-values'] }`.
+
+We recommend you update your code to fix the errors and only override the rule in your own stylelint configuration if you have a strong reason to (for example, adding exceptions for `property-no-deprecated` because of the browsers you need to support).
+
+### Removed rules
+
+The upgrades of the configuration packages also remove some rules or options. While this won’t trigger new linting errors, this means some verifications will no longer happen on your code.
+
+This release also removes the following rules:
+
+- [color-no-invalid-hex](https://stylelint.io/user-guide/rules/color-no-invalid-hex/)   
+- [function-linear-gradient-no-nonstandard-direction](https://stylelint.io/user-guide/rules/function-linear-gradient-no-nonstandard-direction/)  
+- [function-no-unknown](https://stylelint.io/user-guide/rules/function-no-unknown/)  
+- [unit-no-unknown](https://stylelint.io/user-guide/rules/function-no-unknown/)
+
+If you find these rules useful for your project, you can add them back in your own stylelint configuration file.
+
+If you use the SCSS configuration, this release also removes the following rules:
+
+- [no-descending-specificity](https://stylelint.io/user-guide/rules/no-descending-specificity/)  
+- [no-duplicate-selectors](https://stylelint.io/user-guide/rules/no-duplicate-selectors/)
+
+Those have been disabled due to false positives since Sass started following standard CSS nesting and we recommend you keep them disabled.
+
 ## 2.0.0
 
 This release upgrades to Stylelint 16 and [removes rules deprecated in Stylelint 15](#breaking-change-removal-of-stylistic-rules)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,65 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+### Breaking change: Requires Stylelint 17 and [Node.js](http://Node.js) v20.19.0+
+
+This release upgrades Stylelint to version 17, which requires a minimum Node.js version of v20.19.0.
+
+If you use the Stylelint JavaScript API, note that Stylelint 17 now only supports [ES Modules](https://nodejs.org/api/esm.html) and no longer supports [CommonJS](https://nodejs.org/api/modules.html).
+
+Read about breaking changes in the Stylelint [Migrating to v17.0.0](https://stylelint.io/migration-guide/to-17/) guide.
+
+### Breaking change: New or re-configured Stylelint rules
+
+This release also upgrades the following configuration packages used by stylelint-config-gds:
+
+- [stylelint-config-standard](https://github.com/stylelint/stylelint-config-standard/tree/40.0.0) to version 40.0.0 and the [stylelint-config-recommended](https://github.com/stylelint/stylelint-config-recommended/tree/18.0.0) it depends on to version 18.0.0  
+- [stylelint-config-standard-scss](https://github.com/stylelint-scss/stylelint-config-standard-scss/tree/v17.0.0) to version 17.0.0 and the [stylelint-config-recommended-scss](https://github.com/stylelint-scss/stylelint-config-recommended-scss/tree/v17.0.0) it depends on to version 17.0.0
+
+You may see new errors when linting from the following new rules:
+
+- [block-no-redundant-nested-style-rules](https://stylelint.io/user-guide/rules/block-no-redundant-nested-style-rules/)  
+- [color-function-alias-notation](https://stylelint.io/user-guide/rules/color-function-alias-notation/) (automatically fixable by running `stylelint --fix`)  
+- [container-name-pattern](https://stylelint.io/user-guide/rules/container-name-pattern/)   
+- [layer-name-pattern](https://stylelint.io/user-guide/rules/layer-name-pattern/)  
+- [media-type-no-deprecated](https://stylelint.io/user-guide/rules/media-type-no-deprecated/)  
+- [nesting-selector-no-missing-scoping-root](https://stylelint.io/user-guide/rules/nesting-selector-no-missing-scoping-root/)  
+- [no-invalid-position-declaration](https://stylelint.io/user-guide/rules/no-invalid-position-declaration/)  
+- [property-no-deprecated](https://stylelint.io/user-guide/rules/property-no-deprecated/)  
+- [syntax-string-no-invalid](https://stylelint.io/user-guide/rules/syntax-string-no-invalid/)  
+- [at-rule-descriptor-no-unknown](https://stylelint.io/user-guide/rules/at-rule-descriptor-no-unknown/)  
+- [at-rule-descriptor-value-no-unknown](https://stylelint.io/user-guide/rules/at-rule-descriptor-value-no-unknown/)  
+- [at-rule-no-deprecated](https://stylelint.io/user-guide/rules/at-rule-no-deprecated/)  
+- [declaration-property-value-keyword-no-deprecated](https://stylelint.io/user-guide/rules/declaration-property-value-keyword-no-deprecated/)  
+- [declaration-property-value-no-unknown](https://stylelint.io/user-guide/rules/declaration-property-value-no-unknown/)  
+- [media-feature-name-value-no-unknown](https://stylelint.io/user-guide/rules/media-feature-name-value-no-unknown/)
+
+You may also see new errors from the [string-no-newline](https://stylelint.io/user-guide/rules/string-no-newline/) rule, now configured with `{ ignore: ['at-rule-preludes', 'declaration-values'] }`.
+
+We recommend you update your code to fix the errors and only override the rule in your own stylelint configuration if you have a strong reason to (for example, adding exceptions for `property-no-deprecated` because of the browsers you need to support).
+
+### Removed rules
+
+The upgrades of the configuration packages also remove some rules or options. While this will not  trigger new linting errors, it means some verifications will no longer run on your code.
+
+This release also removes the following rules:
+
+- [color-no-invalid-hex](https://stylelint.io/user-guide/rules/color-no-invalid-hex/)   
+- [function-linear-gradient-no-nonstandard-direction](https://stylelint.io/user-guide/rules/function-linear-gradient-no-nonstandard-direction/)  
+- [function-no-unknown](https://stylelint.io/user-guide/rules/function-no-unknown/)  
+- [unit-no-unknown](https://stylelint.io/user-guide/rules/function-no-unknown/)
+
+If you find these rules useful for your project, you can add them back in your own stylelint configuration file.
+
+If you use the [SCSS configuration](https://github.com/alphagov/stylelint-config-gds/blob/main/README.md#usage), this release also removes the following rules:
+
+- [no-descending-specificity](https://stylelint.io/user-guide/rules/no-descending-specificity/)  
+- [no-duplicate-selectors](https://stylelint.io/user-guide/rules/no-duplicate-selectors/)
+
+[\`stylelint-config-recommended-scss\` disabled those rules](https://github.com/stylelint-scss/stylelint-config-recommended-scss/releases/tag/v17.0.0) due to false positives since Sass started following standard CSS nesting. We recommend you keep them disabled.
+
 ## 2.0.0
 
 This release upgrades to Stylelint 16 and [removes rules deprecated in Stylelint 15](#breaking-change-removal-of-stylistic-rules)

--- a/css-rules.js
+++ b/css-rules.js
@@ -102,7 +102,6 @@ module.exports = {
       // a loose interpretation on hyphenated BEM in order to allow BEM
       // style and govuk-! overrides
       /^[a-z]([a-z0-9-_!])*$/, {
-        resolveNestedSelectors: true,
         message: 'Class names may only contain [a-z0-9-_!] characters and ' +
           'must start with [a-z]'
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,17 +9,17 @@
       "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
-        "stylelint-config-standard": "^36.0.1",
-        "stylelint-config-standard-scss": "^13.0.0"
+        "stylelint-config-standard": "^40.0.0",
+        "stylelint-config-standard-scss": "^17.0.0"
       },
       "devDependencies": {
         "jest": "^30.3.0",
         "jest-light-runner": "^0.7.11",
         "standard": "^17.1.2",
-        "stylelint": "^16.11.0"
+        "stylelint": "^17.4.0"
       },
       "peerDependencies": {
-        "stylelint": "^16.0.2"
+        "stylelint": "^17.4.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -521,31 +521,66 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@csstools/css-parser-algorithms": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.4.tgz",
-      "integrity": "sha512-Up7rBoV77rv29d3uKHUIVubz1BTcgyUK72IvCQAbfbMv584xHcGKCKbWh7i8hPrRJ7qU4Y8IO3IY9m+iTB7P3A==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@csstools/css-tokenizer": "^3.0.3"
+    "node_modules/@cacheable/memory": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.0.8.tgz",
+      "integrity": "sha512-FvEb29x5wVwu/Kf93IWwsOOEuhHh6dYCJF3vcKLzXc0KXIW181AOzv6ceT4ZpBHDvAfG60eqb+ekmrnLHIy+jw==",
+      "license": "MIT",
+      "dependencies": {
+        "@cacheable/utils": "^2.4.0",
+        "@keyv/bigmap": "^1.3.1",
+        "hookified": "^1.15.1",
+        "keyv": "^5.6.0"
       }
     },
-    "node_modules/@csstools/css-tokenizer": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.3.tgz",
-      "integrity": "sha512-UJnjoFsmxfKUdNYdWgOB0mWUypuLvAfQPH1+pyvRJs6euowbFkFC6P13w1l8mJyi3vxYMxc9kld5jZEGRQs6bw==",
+    "node_modules/@cacheable/memory/node_modules/@keyv/bigmap": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.3.1.tgz",
+      "integrity": "sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hashery": "^1.4.0",
+        "hookified": "^1.15.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "keyv": "^5.6.0"
+      }
+    },
+    "node_modules/@cacheable/memory/node_modules/keyv": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@keyv/serialize": "^1.1.1"
+      }
+    },
+    "node_modules/@cacheable/utils": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.4.0.tgz",
+      "integrity": "sha512-PeMMsqjVq+bF0WBsxFBxr/WozBJiZKY0rUojuaCoIaKnEl3Ju1wfEwS+SV1DU/cSe8fqHIPiYJFif8T3MVt4cQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hashery": "^1.5.0",
+        "keyv": "^5.6.0"
+      }
+    },
+    "node_modules/@cacheable/utils/node_modules/keyv": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@keyv/serialize": "^1.1.1"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+      "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
       "funding": [
         {
           "type": "github",
@@ -556,14 +591,76 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
+      "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.0.29",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.29.tgz",
+      "integrity": "sha512-jx9GjkkP5YHuTmko2eWAvpPnb0mB4mGRr2U7XwVNwevm8nlpobZEVk+GNmiYMk2VuA75v+plfXWyroWKmICZXg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0"
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@csstools/media-query-list-parser": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-4.0.2.tgz",
-      "integrity": "sha512-EUos465uvVvMJehckATTlNqGj4UJWkTmdWuDMjqvSUkjGpmOyFZBVwb4knxCm/k2GMTXY+c/5RkdndzFYWeX5A==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-5.0.0.tgz",
+      "integrity": "sha512-T9lXmZOfnam3eMERPsszjY5NK0jX8RmThmmm99FZ8b7z8yMaFZWKwLWGZuTwdO3ddRY5fy13GmmEYZXB4I98Eg==",
       "funding": [
         {
           "type": "github",
@@ -574,39 +671,75 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
+      "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^3.0.4",
-        "@csstools/css-tokenizer": "^3.0.3"
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
       }
     },
-    "node_modules/@dual-bundle/import-meta-resolve": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@dual-bundle/import-meta-resolve/-/import-meta-resolve-4.1.0.tgz",
-      "integrity": "sha512-+nxncfwHM5SgAtrVzgpzJOI1ol0PkumhVo469KCf9lUi21IGcY90G98VuHm9VRrUypmAzawAHO9bs6hqeADaVg==",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
+    "node_modules/@csstools/selector-resolve-nested": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/selector-resolve-nested/-/selector-resolve-nested-4.0.0.tgz",
+      "integrity": "sha512-9vAPxmp+Dx3wQBIUwc1v7Mdisw1kbbaGqXUM8QLTgWg7SoPGYtXBsMXvsFs/0Bn5yoFhcktzxNZGNaUt0VjgjA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "postcss-selector-parser": "^7.1.1"
+      }
+    },
+    "node_modules/@csstools/selector-specificity": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-6.0.0.tgz",
+      "integrity": "sha512-4sSgl78OtOXEX/2d++8A83zHNTgwCJMaR24FvsYL7Uf/VS8HZk9PTwR51elTbGqMuwH3szLvvOXEaVnqn0Z3zA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "postcss-selector-parser": "^7.1.1"
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.8.1.tgz",
-      "integrity": "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.1.0",
+        "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
-      "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -615,9 +748,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
-      "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1325,6 +1458,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@keyv/serialize": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
+      "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
+      "license": "MIT"
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -1387,6 +1526,18 @@
       "integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.1",
@@ -1935,14 +2086,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/array-union": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/array.prototype.findlast": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz",
@@ -2041,6 +2184,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -2274,6 +2418,28 @@
         "node": ">=10"
       }
     },
+    "node_modules/cacheable": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.3.3.tgz",
+      "integrity": "sha512-iffYMX4zxKp54evOH27fm92hs+DeC1DhXmNVN8Tr94M/iZIV42dqTHSR2Ik4TOSPyOAwKr7Yu3rN9ALoLkbWyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@cacheable/memory": "^2.0.8",
+        "@cacheable/utils": "^2.4.0",
+        "hookified": "^1.15.0",
+        "keyv": "^5.6.0",
+        "qified": "^0.6.0"
+      }
+    },
+    "node_modules/cacheable/node_modules/keyv": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@keyv/serialize": "^1.1.1"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
@@ -2501,20 +2667,22 @@
       }
     },
     "node_modules/css-functions-list": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.2.3.tgz",
-      "integrity": "sha512-IQOkD3hbR5KrN93MtcYuad6YPuTSUhntLHDuLEbFWE+ff2/XSZNdZG+LcbbIW5AXKg/WFIfYItIzVoHngHXZzA==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.3.3.tgz",
+      "integrity": "sha512-8HFEBPKhOpJPEPu70wJJetjKta86Gw9+CCyCnB3sui2qQfOvRyqBy4IKLKKAwdMpWb2lHXWk9Wb4Z6AmaUT1Pg==",
+      "license": "MIT",
       "engines": {
-        "node": ">=12 || >=16"
+        "node": ">=12"
       }
     },
     "node_modules/css-tree": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.0.1.tgz",
-      "integrity": "sha512-8Fxxv+tGhORlshCdCwnNJytvlvq46sOLSYEx2ZIGurahWvMucSRnyjPA3AmrMq4VPRYbHVpWj5VkiVasrM2H4Q==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "license": "MIT",
       "dependencies": {
-        "mdn-data": "2.12.1",
-        "source-map-js": "^1.0.1"
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
@@ -2583,9 +2751,10 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -2669,17 +2838,6 @@
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/dir-glob": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-      "dependencies": {
-        "path-type": "^4.0.0"
-      },
       "engines": {
         "node": ">=8"
       }
@@ -3598,15 +3756,16 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-glob": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
-      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
         "glob-parent": "^5.1.2",
         "merge2": "^1.3.0",
-        "micromatch": "^4.0.4"
+        "micromatch": "^4.0.8"
       },
       "engines": {
         "node": ">=8.6.0"
@@ -3716,9 +3875,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
-      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.4.tgz",
+      "integrity": "sha512-3+mMldrTAPdta5kjX2G2J7iX4zxtnwpdA8Tr2ZSjkyPSanvbZAcy6flmtnXbEybHrDcU9641lxrMfFuUxVz9vA==",
       "license": "ISC"
     },
     "node_modules/for-each": {
@@ -3835,6 +3994,18 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-east-asian-width": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
@@ -3929,6 +4100,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -3991,6 +4163,59 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/globby": {
+      "version": "16.1.1",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-16.1.1.tgz",
+      "integrity": "sha512-dW7vl+yiAJSp6aCekaVnVJxurRv7DCOLyXqEG3RYMYUg7AuJ2jCqPkZTA8ooqC2vtnkaMcV5WfFBMuEnTu1OQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "fast-glob": "^3.3.3",
+        "ignore": "^7.0.5",
+        "is-path-inside": "^4.0.0",
+        "slash": "^5.1.0",
+        "unicorn-magic": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globby/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/globby/node_modules/is-path-inside": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
+      "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globby/node_modules/slash": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/globjoin": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
@@ -4045,6 +4270,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -4100,6 +4326,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/hashery": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/hashery/-/hashery-1.5.0.tgz",
+      "integrity": "sha512-nhQ6ExaOIqti2FDWoEMWARUqIKyjr2VcZzXShrI+A3zpeiuPWzx6iPftt44LhP74E5sW36B75N6VHbvRtpvO6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "hookified": "^1.14.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -4112,6 +4350,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hookified": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.15.1.tgz",
+      "integrity": "sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==",
+      "license": "MIT"
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -4120,11 +4364,12 @@
       "license": "MIT"
     },
     "node_modules/html-tags": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.3.1.tgz",
-      "integrity": "sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-5.1.0.tgz",
+      "integrity": "sha512-n6l5uca7/y5joxZ3LUePhzmBFUJ+U2YWzhMa8XUTecSeSlQiZdF5XAd/Q3/WUl0VsXgUwWi8I7CNIwdI5WN1SQ==",
+      "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=20.10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -4190,6 +4435,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/imurmurhash": {
@@ -5645,7 +5900,8 @@
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true
     },
     "node_modules/json-parse-better-errors": {
       "version": "1.0.2",
@@ -5699,6 +5955,7 @@
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
       "dependencies": {
         "json-buffer": "3.0.1"
       }
@@ -5712,9 +5969,10 @@
       }
     },
     "node_modules/known-css-properties": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.29.0.tgz",
-      "integrity": "sha512-Ne7wqW7/9Cz54PDt4I3tcV+hAyat8ypyOGzYRJQfdxnnjeWsTxt1cy8pjvvKeI5kfXuyvULyeeAvwvvtAX3ayQ=="
+      "version": "0.37.0",
+      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.37.0.tgz",
+      "integrity": "sha512-JCDrsP4Z1Sb9JwG0aJ8Eo2r7k4Ou5MwmThS/6lcIe1ICyb7UBJKGRIUUdqc2ASdE/42lgz6zFUnzAIhtXnBVrQ==",
+      "license": "MIT"
     },
     "node_modules/leven": {
       "version": "3.1.0",
@@ -5811,7 +6069,8 @@
     "node_modules/lodash.truncate": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
-      "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw=="
+      "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
+      "license": "MIT"
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -5876,25 +6135,28 @@
       }
     },
     "node_modules/mathml-tag-names": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz",
-      "integrity": "sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-4.0.0.tgz",
+      "integrity": "sha512-aa6AU2Pcx0VP/XWnh8IGL0SYSgQHDT6Ucror2j2mXeFAlN3ahaNs8EZtG1YiticMkSLj3Gt6VPFfZogt7G5iFQ==",
+      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/mdn-data": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.1.tgz",
-      "integrity": "sha512-rsfnCbOHjqrhWxwt5/wtSLzpoKTzW7OXdT5lLOIH1OTYhWu9rRJveGq0sKvDZODABH7RX+uoR+DYcpFnq4Tf6Q=="
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "license": "CC0-1.0"
     },
     "node_modules/meow": {
-      "version": "13.2.0",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
-      "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-14.1.0.tgz",
+      "integrity": "sha512-EDYo6VlmtnumlcBCbh1gLJ//9jvM/ndXHfVXIFrZVr6fGcwTUyCTFNTLCKuY3ffbK8L/+3Mzqnd58RojiZqHVw==",
+      "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -5910,6 +6172,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 8"
       }
@@ -5974,15 +6237,16 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/nanoid": {
-      "version": "3.3.8",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
-      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -6313,24 +6577,15 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/path-type": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
     "node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "license": "MIT",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "engines": {
         "node": ">=8.6"
       },
@@ -6439,9 +6694,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.49",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
-      "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
       "funding": [
         {
           "type": "opencollective",
@@ -6456,8 +6711,9 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.7",
+        "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -6468,7 +6724,8 @@
     "node_modules/postcss-media-query-parser": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
-      "integrity": "sha512-3sOlxmbKcSHMjlUXQZKQ06jOswE7oVkXPxmZdoB1r5l0q6gTFTQSHxNxOrCccElbW7dxNytifNEo8qidX2Vsig=="
+      "integrity": "sha512-3sOlxmbKcSHMjlUXQZKQ06jOswE7oVkXPxmZdoB1r5l0q6gTFTQSHxNxOrCccElbW7dxNytifNEo8qidX2Vsig==",
+      "license": "MIT"
     },
     "node_modules/postcss-resolve-nested-selector": {
       "version": "0.1.6",
@@ -6518,6 +6775,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=12.0"
       },
@@ -6526,9 +6784,10 @@
       }
     },
     "node_modules/postcss-selector-parser": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
-      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
+      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+      "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -6622,6 +6881,18 @@
       ],
       "license": "MIT"
     },
+    "node_modules/qified": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/qified/-/qified-0.6.0.tgz",
+      "integrity": "sha512-tsSGN1x3h569ZSU1u6diwhltLyfUWDp3YbFHedapTmpBl0B3P6U3+Qptg7xu+v+1io1EwhdPyyRHYbEw0KN2FA==",
+      "license": "MIT",
+      "dependencies": {
+        "hookified": "^1.14.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -6713,6 +6984,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6751,6 +7023,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -6927,6 +7200,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -6935,6 +7209,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
       "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "astral-regex": "^2.0.0",
@@ -7246,9 +7521,9 @@
       }
     },
     "node_modules/stylelint": {
-      "version": "16.11.0",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.11.0.tgz",
-      "integrity": "sha512-zrl4IrKmjJQ+h9FoMp69UMCq5SxeHk0URhxUBj4d3ISzo/DplOFBJZc7t7Dr6otB+1bfbbKNLOmCDpzKSlW+Nw==",
+      "version": "17.4.0",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-17.4.0.tgz",
+      "integrity": "sha512-3kQ2/cHv3Zt8OBg+h2B8XCx9evEABQIrv4hh3uXahGz/ZEHrTR80zxBiK2NfXNaSoyBzxO1pjsz1Vhdzwn5XSw==",
       "funding": [
         {
           "type": "opencollective",
@@ -7259,57 +7534,57 @@
           "url": "https://github.com/sponsors/stylelint"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "@csstools/css-parser-algorithms": "^3.0.4",
-        "@csstools/css-tokenizer": "^3.0.3",
-        "@csstools/media-query-list-parser": "^4.0.2",
-        "@csstools/selector-specificity": "^5.0.0",
-        "@dual-bundle/import-meta-resolve": "^4.1.0",
-        "balanced-match": "^2.0.0",
+        "@csstools/css-calc": "^3.1.1",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.27",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "@csstools/media-query-list-parser": "^5.0.0",
+        "@csstools/selector-resolve-nested": "^4.0.0",
+        "@csstools/selector-specificity": "^6.0.0",
         "colord": "^2.9.3",
         "cosmiconfig": "^9.0.0",
-        "css-functions-list": "^3.2.3",
-        "css-tree": "^3.0.1",
-        "debug": "^4.3.7",
-        "fast-glob": "^3.3.2",
+        "css-functions-list": "^3.3.3",
+        "css-tree": "^3.1.0",
+        "debug": "^4.4.3",
+        "fast-glob": "^3.3.3",
         "fastest-levenshtein": "^1.0.16",
-        "file-entry-cache": "^9.1.0",
+        "file-entry-cache": "^11.1.2",
         "global-modules": "^2.0.0",
-        "globby": "^11.1.0",
+        "globby": "^16.1.0",
         "globjoin": "^0.1.4",
-        "html-tags": "^3.3.1",
-        "ignore": "^6.0.2",
+        "html-tags": "^5.1.0",
+        "ignore": "^7.0.5",
+        "import-meta-resolve": "^4.2.0",
         "imurmurhash": "^0.1.4",
         "is-plain-object": "^5.0.0",
-        "known-css-properties": "^0.35.0",
-        "mathml-tag-names": "^2.1.3",
-        "meow": "^13.2.0",
+        "mathml-tag-names": "^4.0.0",
+        "meow": "^14.0.0",
         "micromatch": "^4.0.8",
         "normalize-path": "^3.0.0",
         "picocolors": "^1.1.1",
-        "postcss": "^8.4.49",
-        "postcss-resolve-nested-selector": "^0.1.6",
+        "postcss": "^8.5.6",
         "postcss-safe-parser": "^7.0.1",
-        "postcss-selector-parser": "^7.0.0",
+        "postcss-selector-parser": "^7.1.1",
         "postcss-value-parser": "^4.2.0",
-        "resolve-from": "^5.0.0",
-        "string-width": "^4.2.3",
-        "supports-hyperlinks": "^3.1.0",
+        "string-width": "^8.1.1",
+        "supports-hyperlinks": "^4.4.0",
         "svg-tags": "^1.0.0",
-        "table": "^6.8.2",
-        "write-file-atomic": "^5.0.1"
+        "table": "^6.9.0",
+        "write-file-atomic": "^7.0.0"
       },
       "bin": {
         "stylelint": "bin/stylelint.mjs"
       },
       "engines": {
-        "node": ">=18.12.0"
+        "node": ">=20.19.0"
       }
     },
     "node_modules/stylelint-config-recommended": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-14.0.1.tgz",
-      "integrity": "sha512-bLvc1WOz/14aPImu/cufKAZYfXs/A/owZfSMZ4N+16WGXLoX5lOir53M6odBxvhgmgdxCVnNySJmZKx73T93cg==",
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-18.0.0.tgz",
+      "integrity": "sha512-mxgT2XY6YZ3HWWe3Di8umG6aBmWmHTblTgu/f10rqFXnyWxjKWwNdjSWkgkwCtxIKnqjSJzvFmPT5yabVIRxZg==",
       "funding": [
         {
           "type": "opencollective",
@@ -7320,28 +7595,30 @@
           "url": "https://github.com/sponsors/stylelint"
         }
       ],
+      "license": "MIT",
       "engines": {
-        "node": ">=18.12.0"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
-        "stylelint": "^16.1.0"
+        "stylelint": "^17.0.0"
       }
     },
     "node_modules/stylelint-config-recommended-scss": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-14.0.0.tgz",
-      "integrity": "sha512-HDvpoOAQ1RpF+sPbDOT2Q2/YrBDEJDnUymmVmZ7mMCeNiFSdhRdyGEimBkz06wsN+HaFwUh249gDR+I9JR7Onw==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-17.0.0.tgz",
+      "integrity": "sha512-VkVD9r7jfUT/dq3mA3/I1WXXk2U71rO5wvU2yIil9PW5o1g3UM7Xc82vHmuVJHV7Y8ok5K137fmW5u3HbhtTOA==",
+      "license": "MIT",
       "dependencies": {
         "postcss-scss": "^4.0.9",
-        "stylelint-config-recommended": "^14.0.0",
-        "stylelint-scss": "^6.0.0"
+        "stylelint-config-recommended": "^18.0.0",
+        "stylelint-scss": "^7.0.0"
       },
       "engines": {
-        "node": ">=18.12.0"
+        "node": ">=20"
       },
       "peerDependencies": {
         "postcss": "^8.3.3",
-        "stylelint": "^16.0.2"
+        "stylelint": "^17.0.0"
       },
       "peerDependenciesMeta": {
         "postcss": {
@@ -7350,9 +7627,9 @@
       }
     },
     "node_modules/stylelint-config-standard": {
-      "version": "36.0.1",
-      "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-36.0.1.tgz",
-      "integrity": "sha512-8aX8mTzJ6cuO8mmD5yon61CWuIM4UD8Q5aBcWKGSf6kg+EC3uhB+iOywpTK4ca6ZL7B49en8yanOFtUW0qNzyw==",
+      "version": "40.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-40.0.0.tgz",
+      "integrity": "sha512-EznGJxOUhtWck2r6dJpbgAdPATIzvpLdK9+i5qPd4Lx70es66TkBPljSg4wN3Qnc6c4h2n+WbUrUynQ3fanjHw==",
       "funding": [
         {
           "type": "opencollective",
@@ -7363,30 +7640,32 @@
           "url": "https://github.com/sponsors/stylelint"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "stylelint-config-recommended": "^14.0.1"
+        "stylelint-config-recommended": "^18.0.0"
       },
       "engines": {
-        "node": ">=18.12.0"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
-        "stylelint": "^16.1.0"
+        "stylelint": "^17.0.0"
       }
     },
     "node_modules/stylelint-config-standard-scss": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-standard-scss/-/stylelint-config-standard-scss-13.0.0.tgz",
-      "integrity": "sha512-WaLvkP689qSYUpJQPCo30TFJSSc3VzvvoWnrgp+7PpVby5o8fRUY1cZcP0sePZfjrFl9T8caGhcKg0GO34VDiQ==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-standard-scss/-/stylelint-config-standard-scss-17.0.0.tgz",
+      "integrity": "sha512-uLJS6xgOCBw5EMsDW7Ukji8l28qRoMnkRch15s0qwZpskXvWt9oPzMmcYM307m9GN4MxuWLsQh4I6hU9yI53cQ==",
+      "license": "MIT",
       "dependencies": {
-        "stylelint-config-recommended-scss": "^14.0.0",
-        "stylelint-config-standard": "^36.0.0"
+        "stylelint-config-recommended-scss": "^17.0.0",
+        "stylelint-config-standard": "^40.0.0"
       },
       "engines": {
-        "node": ">=18.12.0"
+        "node": ">=20"
       },
       "peerDependencies": {
         "postcss": "^8.3.3",
-        "stylelint": "^16.1.0"
+        "stylelint": "^17.0.0"
       },
       "peerDependenciesMeta": {
         "postcss": {
@@ -7395,128 +7674,128 @@
       }
     },
     "node_modules/stylelint-scss": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-6.0.0.tgz",
-      "integrity": "sha512-N1xV/Ef5PNRQQt9E45unzGvBUN1KZxCI8B4FgN/pMfmyRYbZGVN4y9qWlvOMdScU17c8VVCnjIHTVn38Bb6qSA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-7.0.0.tgz",
+      "integrity": "sha512-H88kCC+6Vtzj76NsC8rv6x/LW8slBzIbyeSjsKVlS+4qaEJoDrcJR4L+8JdrR2ORdTscrBzYWiiT2jq6leYR1Q==",
+      "license": "MIT",
       "dependencies": {
-        "known-css-properties": "^0.29.0",
+        "css-tree": "^3.0.1",
+        "is-plain-object": "^5.0.0",
+        "known-css-properties": "^0.37.0",
+        "mdn-data": "^2.25.0",
         "postcss-media-query-parser": "^0.2.3",
-        "postcss-resolve-nested-selector": "^0.1.1",
-        "postcss-selector-parser": "^6.0.13",
+        "postcss-resolve-nested-selector": "^0.1.6",
+        "postcss-selector-parser": "^7.1.1",
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
-        "node": ">=18.12.0"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
-        "stylelint": "^16.0.2"
+        "stylelint": "^16.8.2 || ^17.0.0"
       }
     },
-    "node_modules/stylelint/node_modules/@csstools/selector-specificity": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-5.0.0.tgz",
-      "integrity": "sha512-PCqQV3c4CoVm3kdPhyeZ07VmBRdH2EpMFA/pd9OASpOEC3aXNGoqPDAZ80D0cLpMBxnmk0+yNhGsEx31hq7Gtw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
+    "node_modules/stylelint/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=12"
       },
-      "peerDependencies": {
-        "postcss-selector-parser": "^7.0.0"
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
-    },
-    "node_modules/stylelint/node_modules/balanced-match": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-2.0.0.tgz",
-      "integrity": "sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA=="
     },
     "node_modules/stylelint/node_modules/file-entry-cache": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-9.1.0.tgz",
-      "integrity": "sha512-/pqPFG+FdxWQj+/WSuzXSDaNzxgTLr/OrR1QuqfEZzDakpdYE70PwUxL7BPUa8hpjbvY1+qvCl8k+8Tq34xJgg==",
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.2.tgz",
+      "integrity": "sha512-N2WFfK12gmrK1c1GXOqiAJ1tc5YE+R53zvQ+t5P8S5XhnmKYVB5eZEiLNZKDSmoG8wqqbF9EXYBBW/nef19log==",
+      "license": "MIT",
       "dependencies": {
-        "flat-cache": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
+        "flat-cache": "^6.1.20"
       }
     },
     "node_modules/stylelint/node_modules/flat-cache": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-5.0.0.tgz",
-      "integrity": "sha512-JrqFmyUl2PnPi1OvLyTVHnQvwQ0S+e6lGSwu8OkAZlSaNIZciTY2H/cOOROxsBA1m/LZNHDsqAgDZt6akWcjsQ==",
+      "version": "6.1.20",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.20.tgz",
+      "integrity": "sha512-AhHYqwvN62NVLp4lObVXGVluiABTHapoB57EyegZVmazN+hhGhLTn3uZbOofoTw4DSDvVCadzzyChXhOAvy8uQ==",
+      "license": "MIT",
       "dependencies": {
-        "flatted": "^3.3.1",
-        "keyv": "^4.5.4"
-      },
-      "engines": {
-        "node": ">=18"
+        "cacheable": "^2.3.2",
+        "flatted": "^3.3.3",
+        "hookified": "^1.15.0"
       }
     },
-    "node_modules/stylelint/node_modules/globby": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+    "node_modules/stylelint/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/stylelint/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/stylelint/node_modules/string-width": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.0.tgz",
+      "integrity": "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==",
+      "license": "MIT",
       "dependencies": {
-        "array-union": "^2.1.0",
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.2.9",
-        "ignore": "^5.2.0",
-        "merge2": "^1.4.1",
-        "slash": "^3.0.0"
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/stylelint/node_modules/globby/node_modules/ignore": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
-      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/stylelint/node_modules/ignore": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-6.0.2.tgz",
-      "integrity": "sha512-InwqeHHN2XpumIkMvpl/DCJVrAHgCsG5+cn1XlnLWGwtZBm8QJfSusItfrwx81CTp5agNZqpKU2J/ccC5nGT4A==",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/stylelint/node_modules/known-css-properties": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.35.0.tgz",
-      "integrity": "sha512-a/RAk2BfKk+WFGhhOCAYqSiFLc34k8Mt/6NWRI4joER0EYUzXIcFivjjnoD3+XU1DggLn/tZc3DOAgke7l8a4A=="
-    },
-    "node_modules/stylelint/node_modules/postcss-selector-parser": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.0.0.tgz",
-      "integrity": "sha512-9RbEr1Y7FFfptd/1eEdntyjMwLeghW1bHX9GWjXo19vx4ytPQhANltvVxDggzJl7mnWM+dX28kb6cyS/4iQjlQ==",
+    "node_modules/stylelint/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
       "dependencies": {
-        "cssesc": "^3.0.0",
-        "util-deprecate": "^1.0.2"
+        "ansi-regex": "^6.2.2"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/stylelint/node_modules/write-file-atomic": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-7.0.1.tgz",
+      "integrity": "sha512-OTIk8iR8/aCRWBqvxrzxR0hgxWpnYBblY1S5hDWBQfk/VFmJwzmJgQFN3WsoUKHISv2eAwe+PpbUzyL1CKTLXg==",
+      "license": "ISC",
+      "dependencies": {
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -7525,18 +7804,43 @@
       }
     },
     "node_modules/supports-hyperlinks": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.1.0.tgz",
-      "integrity": "sha512-2rn0BZ+/f7puLOHZm1HOJfwBggfaHXUpPUSSG/SWM4TWp5KCfmNYwnC3hruy2rZlMnmWZ+QAGpZfchu3f3695A==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-4.4.0.tgz",
+      "integrity": "sha512-UKbpT93hN5Nr9go5UY7bopIB9YQlMz9nm/ct4IXt/irb5YRkn9WaqrOBJGZ5Pwvsd5FQzSVeYlGdXoCAPQZrPg==",
+      "license": "MIT",
       "dependencies": {
-        "has-flag": "^4.0.0",
-        "supports-color": "^7.0.0"
+        "has-flag": "^5.0.1",
+        "supports-color": "^10.2.2"
       },
       "engines": {
-        "node": ">=14.18"
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
+      }
+    },
+    "node_modules/supports-hyperlinks/node_modules/has-flag": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-5.0.1.tgz",
+      "integrity": "sha512-CsNUt5x9LUdx6hnk/E2SZLsDyvfqANZSUq4+D3D8RzDJ2M+HDTIkF60ibS1vHaK55vzgiZw1bEPFG9yH7l33wA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-hyperlinks/node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/supports-preserve-symlinks-flag": {
@@ -7557,9 +7861,10 @@
       "integrity": "sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q="
     },
     "node_modules/table": {
-      "version": "6.8.2",
-      "resolved": "https://registry.npmjs.org/table/-/table-6.8.2.tgz",
-      "integrity": "sha512-w2sfv80nrAh2VCbqR5AK27wswXhqcck2AhfnNW76beQXskGZ1V12GwS//yYVa3d3fcvAip2OUnbDAjW2k3v9fA==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.9.0.tgz",
+      "integrity": "sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "ajv": "^8.0.1",
         "lodash.truncate": "^4.4.2",
@@ -7590,7 +7895,8 @@
     "node_modules/table/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",
@@ -7673,10 +7979,11 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
+      "license": "0BSD",
       "optional": true
     },
     "node_modules/type-check": {
@@ -7800,6 +8107,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.4.0.tgz",
+      "integrity": "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/unrs-resolver": {
@@ -8065,6 +8384,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
       "integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "imurmurhash": "^0.1.4",
@@ -8078,6 +8398,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"

--- a/package.json
+++ b/package.json
@@ -49,16 +49,16 @@
   },
   "license": "MIT",
   "dependencies": {
-    "stylelint-config-standard": "^36.0.1",
-    "stylelint-config-standard-scss": "^13.0.0"
+    "stylelint-config-standard": "^40.0.0",
+    "stylelint-config-standard-scss": "^17.0.0"
   },
   "devDependencies": {
     "jest": "^30.3.0",
     "jest-light-runner": "^0.7.11",
     "standard": "^17.1.2",
-    "stylelint": "^16.11.0"
+    "stylelint": "^17.4.0"
   },
   "peerDependencies": {
-    "stylelint": "^16.0.2"
+    "stylelint": "^17.4.0"
   }
 }

--- a/scss-rules.js
+++ b/scss-rules.js
@@ -85,6 +85,16 @@ module.exports = {
         message: 'Placeholders may only contain [a-z0-9-] characters'
       }
     ],
+    // Use the scss version of the rule which accounts for nesting
+    'selector-class-pattern': null,
+    'scss/selector-class-pattern': [
+      // a loose interpretation on hyphenated BEM in order to allow BEM
+      // style and govuk-! overrides
+      /^[a-z]([a-z0-9-_!])*$/, {
+        message: 'Class names may only contain [a-z0-9-_!] characters and ' +
+          'must start with [a-z]'
+      }
+    ],
     // Disable @import needing to be first declarations
     // @import has a different usage in SCSS to CSS and may be scoped or follow SCSS conditionals
     // https://stylelint.io/user-guide/rules/no-invalid-position-at-import-rule/

--- a/test/__snapshots__/css.test.mjs.snap
+++ b/test/__snapshots__/css.test.mjs.snap
@@ -283,7 +283,6 @@ exports[`CSS rules matches snapshots 1`] = `
       /\\^\\[a-z\\]\\(\\[a-z0-9-_!\\]\\)\\*\\$/,
       {
         "message": "Class names may only contain [a-z0-9-_!] characters and must start with [a-z]",
-        "resolveNestedSelectors": true,
       },
     ],
     "selector-id-pattern": [

--- a/test/__snapshots__/css.test.mjs.snap
+++ b/test/__snapshots__/css.test.mjs.snap
@@ -9,13 +9,36 @@ exports[`CSS rules matches snapshots 1`] = `
     "annotation-no-unknown": [
       true,
     ],
+    "at-rule-descriptor-no-unknown": [
+      true,
+    ],
+    "at-rule-descriptor-value-no-unknown": [
+      true,
+    ],
     "at-rule-empty-line-before": null,
+    "at-rule-no-deprecated": [
+      true,
+    ],
     "at-rule-no-unknown": [
       true,
     ],
     "at-rule-no-vendor-prefix": null,
+    "at-rule-prelude-no-invalid": [
+      true,
+      {
+        "ignoreAtRules": [
+          "media",
+        ],
+      },
+    ],
     "block-no-empty": [
       true,
+    ],
+    "block-no-redundant-nested-style-rules": [
+      true,
+    ],
+    "color-function-alias-notation": [
+      "without-alpha",
     ],
     "color-function-notation": [
       "legacy",
@@ -25,9 +48,6 @@ exports[`CSS rules matches snapshots 1`] = `
     ],
     "color-named": [
       "never",
-    ],
-    "color-no-invalid-hex": [
-      true,
     ],
     "comment-empty-line-before": [
       "always",
@@ -45,6 +65,12 @@ exports[`CSS rules matches snapshots 1`] = `
     ],
     "comment-whitespace-inside": [
       "always",
+    ],
+    "container-name-pattern": [
+      "^(--)?([a-z][a-z0-9]*)(-[a-z0-9]+)*$",
+      {
+        "message": [Function],
+      },
     ],
     "custom-media-pattern": [
       "^([a-z][a-z0-9]*)(-[a-z0-9]+)*$",
@@ -103,6 +129,12 @@ exports[`CSS rules matches snapshots 1`] = `
         ],
       },
     ],
+    "declaration-property-value-keyword-no-deprecated": [
+      true,
+    ],
+    "declaration-property-value-no-unknown": [
+      true,
+    ],
     "font-family-name-quotes": [
       "always-where-recommended",
     ],
@@ -115,14 +147,8 @@ exports[`CSS rules matches snapshots 1`] = `
     "function-calc-no-unspaced-operator": [
       true,
     ],
-    "function-linear-gradient-no-nonstandard-direction": [
-      true,
-    ],
     "function-name-case": [
       "lower",
-    ],
-    "function-no-unknown": [
-      true,
     ],
     "function-url-no-scheme-relative": [
       true,
@@ -156,6 +182,12 @@ exports[`CSS rules matches snapshots 1`] = `
         "message": [Function],
       },
     ],
+    "layer-name-pattern": [
+      "^([a-z][a-z0-9]*)([.-][a-z0-9]+)*$",
+      {
+        "message": [Function],
+      },
+    ],
     "length-zero-no-unit": [
       true,
       {
@@ -180,13 +212,22 @@ exports[`CSS rules matches snapshots 1`] = `
       true,
     ],
     "media-feature-name-no-vendor-prefix": null,
+    "media-feature-name-value-no-unknown": [
+      true,
+    ],
     "media-feature-range-notation": [
       "prefix",
     ],
     "media-query-no-invalid": [
       true,
     ],
+    "media-type-no-deprecated": [
+      true,
+    ],
     "named-grid-areas-no-invalid": [
+      true,
+    ],
+    "nesting-selector-no-missing-scoping-root": [
       true,
     ],
     "no-descending-specificity": null,
@@ -205,11 +246,17 @@ exports[`CSS rules matches snapshots 1`] = `
     "no-invalid-position-at-import-rule": [
       true,
     ],
+    "no-invalid-position-declaration": [
+      true,
+    ],
     "no-irregular-whitespace": [
       true,
     ],
     "number-max-precision": [
       4,
+    ],
+    "property-no-deprecated": [
+      true,
     ],
     "property-no-unknown": [
       true,
@@ -286,8 +333,14 @@ exports[`CSS rules matches snapshots 1`] = `
     ],
     "string-no-newline": [
       true,
+      {
+        "ignore": [
+          "at-rule-preludes",
+          "declaration-values",
+        ],
+      },
     ],
-    "unit-no-unknown": [
+    "syntax-string-no-invalid": [
       true,
     ],
     "value-keyword-case": [

--- a/test/__snapshots__/scss.test.mjs.snap
+++ b/test/__snapshots__/scss.test.mjs.snap
@@ -19,12 +19,11 @@ exports[`Scss rules matches snapshots 1`] = `
     "scss/at-if-closing-brace-newline-after": [Function],
     "scss/at-if-closing-brace-space-after": [Function],
     "scss/at-if-no-null": [Function],
-    "scss/at-import-no-partial-leading-underscore": [Function],
-    "scss/at-import-partial-extension": [Function],
-    "scss/at-import-partial-extension-blacklist": [Function],
-    "scss/at-import-partial-extension-whitelist": [Function],
+    "scss/at-import-partial-extension-allowed-list": [Function],
+    "scss/at-import-partial-extension-disallowed-list": [Function],
     "scss/at-mixin-argumentless-call-parentheses": [Function],
     "scss/at-mixin-named-arguments": [Function],
+    "scss/at-mixin-no-risky-nesting-selector": [Function],
     "scss/at-mixin-parentheses-space-before": [Function],
     "scss/at-mixin-pattern": [Function],
     "scss/at-root-no-redundant": [Function],
@@ -37,6 +36,7 @@ exports[`Scss rules matches snapshots 1`] = `
     "scss/comment-no-loud": [Function],
     "scss/declaration-nested-properties": [Function],
     "scss/declaration-nested-properties-no-divided-groups": [Function],
+    "scss/declaration-property-value-no-unknown": [Function],
     "scss/dimension-no-non-numeric-values": [Function],
     "scss/dollar-variable-colon-newline-after": [Function],
     "scss/dollar-variable-colon-space-after": [Function],
@@ -52,24 +52,29 @@ exports[`Scss rules matches snapshots 1`] = `
     "scss/double-slash-comment-inline": [Function],
     "scss/double-slash-comment-whitespace-inside": [Function],
     "scss/function-calculation-no-interpolation": [Function],
+    "scss/function-color-channel": [Function],
     "scss/function-color-relative": [Function],
     "scss/function-disallowed-list": [Function],
     "scss/function-no-unknown": [Function],
     "scss/function-quote-no-quoted-strings-inside": [Function],
     "scss/function-unquote-no-unquoted-strings-inside": [Function],
     "scss/load-no-partial-leading-underscore": [Function],
+    "scss/load-partial-extension": [Function],
     "scss/map-keys-quotes": [Function],
     "scss/media-feature-value-dollar-variable": [Function],
     "scss/no-dollar-variables": [Function],
     "scss/no-duplicate-dollar-variables": [Function],
+    "scss/no-duplicate-load-rules": [Function],
     "scss/no-duplicate-mixins": [Function],
     "scss/no-global-function-names": [Function],
+    "scss/no-unused-private-members": [Function],
     "scss/operator-no-newline-after": [Function],
     "scss/operator-no-newline-before": [Function],
     "scss/operator-no-unspaced": [Function],
     "scss/partial-no-import": [Function],
     "scss/percent-placeholder-pattern": [Function],
     "scss/property-no-unknown": [Function],
+    "scss/selector-class-pattern": [Function],
     "scss/selector-nest-combinators": [Function],
     "scss/selector-no-redundant-nesting-selector": [Function],
     "scss/selector-no-union-class-name": [Function],
@@ -91,16 +96,28 @@ exports[`Scss rules matches snapshots 1`] = `
         ],
       },
     ],
+    "at-rule-descriptor-no-unknown": null,
+    "at-rule-descriptor-value-no-unknown": null,
     "at-rule-disallowed-list": [
       [
         "debug",
       ],
     ],
     "at-rule-empty-line-before": null,
+    "at-rule-no-deprecated": [
+      true,
+    ],
     "at-rule-no-unknown": null,
     "at-rule-no-vendor-prefix": null,
+    "at-rule-prelude-no-invalid": null,
     "block-no-empty": [
       true,
+    ],
+    "block-no-redundant-nested-style-rules": [
+      true,
+    ],
+    "color-function-alias-notation": [
+      "without-alpha",
     ],
     "color-function-notation": [
       "legacy",
@@ -128,6 +145,12 @@ exports[`Scss rules matches snapshots 1`] = `
     "comment-no-empty": null,
     "comment-whitespace-inside": [
       "always",
+    ],
+    "container-name-pattern": [
+      "^(--)?([a-z][a-z0-9]*)(-[a-z0-9]+)*$",
+      {
+        "message": [Function],
+      },
     ],
     "custom-media-pattern": [
       "^([a-z][a-z0-9]*)(-[a-z0-9]+)*$",
@@ -186,6 +209,10 @@ exports[`Scss rules matches snapshots 1`] = `
         ],
       },
     ],
+    "declaration-property-value-keyword-no-deprecated": [
+      true,
+    ],
+    "declaration-property-value-no-unknown": null,
     "font-family-name-quotes": [
       "always-where-recommended",
     ],
@@ -237,11 +264,21 @@ exports[`Scss rules matches snapshots 1`] = `
         "message": [Function],
       },
     ],
+    "layer-name-pattern": [
+      "^([a-z][a-z0-9]*)([.-][a-z0-9]+)*$",
+      {
+        "message": [Function],
+      },
+    ],
     "length-zero-no-unit": [
       true,
       {
         "ignore": [
           "custom-properties",
+        ],
+        "ignorePreludeOfAtRules": [
+          "function",
+          "mixin",
         ],
       },
     ],
@@ -261,20 +298,30 @@ exports[`Scss rules matches snapshots 1`] = `
       true,
     ],
     "media-feature-name-no-vendor-prefix": null,
+    "media-feature-name-value-no-unknown": null,
     "media-feature-range-notation": [
       "prefix",
     ],
     "media-query-no-invalid": null,
+    "media-type-no-deprecated": [
+      true,
+    ],
     "named-grid-areas-no-invalid": [
       true,
+    ],
+    "nesting-selector-no-missing-scoping-root": [
+      true,
+      {
+        "ignoreAtRules": [
+          "mixin",
+        ],
+      },
     ],
     "no-descending-specificity": null,
     "no-duplicate-at-import-rules": [
       true,
     ],
-    "no-duplicate-selectors": [
-      true,
-    ],
+    "no-duplicate-selectors": null,
     "no-empty-source": [
       true,
     ],
@@ -282,11 +329,17 @@ exports[`Scss rules matches snapshots 1`] = `
       true,
     ],
     "no-invalid-position-at-import-rule": null,
+    "no-invalid-position-declaration": [
+      true,
+    ],
     "no-irregular-whitespace": [
       true,
     ],
     "number-max-precision": [
       4,
+    ],
+    "property-no-deprecated": [
+      true,
     ],
     "property-no-unknown": [
       true,
@@ -336,9 +389,6 @@ exports[`Scss rules matches snapshots 1`] = `
     "scss/at-if-no-null": [
       true,
     ],
-    "scss/at-import-partial-extension": [
-      "never",
-    ],
     "scss/at-mixin-argumentless-call-parentheses": [
       "never",
     ],
@@ -365,7 +415,7 @@ exports[`Scss rules matches snapshots 1`] = `
       true,
     ],
     "scss/dollar-variable-colon-space-after": [
-      "always",
+      "always-single-line",
     ],
     "scss/dollar-variable-colon-space-before": [
       "never",
@@ -392,6 +442,9 @@ exports[`Scss rules matches snapshots 1`] = `
     ],
     "scss/load-no-partial-leading-underscore": [
       true,
+    ],
+    "scss/load-partial-extension": [
+      "never",
     ],
     "scss/no-duplicate-mixins": [
       true,
@@ -467,6 +520,9 @@ exports[`Scss rules matches snapshots 1`] = `
       true,
     ],
     "string-no-newline": [
+      true,
+    ],
+    "syntax-string-no-invalid": [
       true,
     ],
     "unit-no-unknown": [

--- a/test/__snapshots__/scss.test.mjs.snap
+++ b/test/__snapshots__/scss.test.mjs.snap
@@ -471,7 +471,6 @@ exports[`Scss rules matches snapshots 1`] = `
       /\\^\\[a-z\\]\\(\\[a-z0-9-_!\\]\\)\\*\\$/,
       {
         "message": "Class names may only contain [a-z0-9-_!] characters and must start with [a-z]",
-        "resolveNestedSelectors": true,
       },
     ],
     "selector-id-pattern": [

--- a/test/__snapshots__/scss.test.mjs.snap
+++ b/test/__snapshots__/scss.test.mjs.snap
@@ -461,18 +461,19 @@ exports[`Scss rules matches snapshots 1`] = `
         "message": "Placeholders may only contain [a-z0-9-] characters",
       },
     ],
+    "scss/selector-class-pattern": [
+      /\\^\\[a-z\\]\\(\\[a-z0-9-_!\\]\\)\\*\\$/,
+      {
+        "message": "Class names may only contain [a-z0-9-_!] characters and must start with [a-z]",
+      },
+    ],
     "selector-anb-no-unmatchable": [
       true,
     ],
     "selector-attribute-quotes": [
       "always",
     ],
-    "selector-class-pattern": [
-      /\\^\\[a-z\\]\\(\\[a-z0-9-_!\\]\\)\\*\\$/,
-      {
-        "message": "Class names may only contain [a-z0-9-_!] characters and must start with [a-z]",
-      },
-    ],
+    "selector-class-pattern": null,
     "selector-id-pattern": [
       /\\^\\[a-z\\]\\(\\[a-z0-9-\\]\\)\\*\\$/,
       {


### PR DESCRIPTION
Both Stylelint and the configuration we depend on need to be updated in a single commit due to `peerDependencies`.

## Diff of the rules

Generating the rules with `npx stylelint . --print-config -c (css|scss.js)` led to the following diffs:
- [for the CSS rules](https://www.diffchecker.com/r3X2Jg2Y/)
- [for the SCSS rules](https://www.diffchecker.com/Mqr3k8zW/)

## Stylelint breaking changes

Stylelint 17 brings the following breaking changes in terms of rules:
- [`selector-class-pattern` no longer has a `resolveNestedSelector` option](https://stylelint.io/migration-guide/to-17/#removed-resolvenestedselectors-option-from-selector-class-pattern)
	- our [CSS rules use the option](https://github.com/alphagov/stylelint-config-gds/blob/daf078e4235a107d6b3d03bff0079572ea88dbe1/css-rules.js#L105)
		- ⚠️ We'll need to remove the option from CSS rules
		- ⚠️ We'll need to update the Sass rules to use `scss/selector-class-pattern`	(so `&<SOME_STRING>` is supported correctly, even if we should discourage its use).
- **[`selector-max-*`](https://stylelint.io/migration-guide/to-17/#changed--specificity-semantic-rules-for-standard-css-nesting)**
	- We configure [`selector-max-id`](https://github.com/alphagov/stylelint-config-gds/blob/daf078e4235a107d6b3d03bff0079572ea88dbe1/css-rules.js#L123) as part of our CSS rules
	- No other `selector-max-*` rules are enabled
- **[`*-specificity` rules](https://stylelint.io/migration-guide/to-17/#changed--specificity-semantic-rules-for-standard-css-nesting)**
	- `stylelint-config-standard` configures [`no-descending-specificity`](https://github.com/stylelint/stylelint-config-recommended/blob/cc35097fde32491e376bc12f777c29e6c2ac341c/index.js#L33)
		- `stylelint-config-recommended-scss` [turns `no-descending-specificity` off](https://github.com/stylelint-scss/stylelint-config-recommended-scss/pull/383/changes) because of [difference of specificity in CSS and Sass output](https://github.com/stylelint-scss/stylelint-scss/issues/1215#issuecomment-3693085913).
- **[`no-duplicate-selectors` and `selector-no-qualifying-type`](https://stylelint.io/migration-guide/to-17/#changed-no-duplicate-selectors-and-selector-no-qualifying-type-for-standard-css-nesting)**
	- `stylelint-config-standard` configures [`no-duplicate-selectors`](https://github.com/stylelint/stylelint-config-recommended/blob/cc35097fde32491e376bc12f777c29e6c2ac341c/index.js#L35)
		- `stylelint-config-recommended-scss` [turns `no-duplicate-selectors` off](https://github.com/stylelint-scss/stylelint-config-recommended-scss/pull/383/changes) because of [difference of how Sass expands nested selectors](https://github.com/stylelint-scss/stylelint-scss/issues/1215#issuecomment-3693085913).
	- our CSS rules configure [`selector-no-qualifying-type`](https://github.com/alphagov/stylelint-config-gds/blob/daf078e4235a107d6b3d03bff0079572ea88dbe1/css-rules.js#L127) 
- **[`*-list` rules] options have been made consistent**
	- our CSS rules [configure `declaration-property-value-disallowed-list`](https://github.com/alphagov/stylelint-config-gds/blob/main/css-rules.js#L53-L56)
	- our CSS rules [configure `function-url-scheme-allowed-list`](https://github.com/alphagov/stylelint-config-gds/blob/daf078e4235a107d6b3d03bff0079572ea88dbe1/css-rules.js#L68)
	- our Scss rules [configure `at-rule-disallowed-list`](https://github.com/alphagov/stylelint-config-gds/blob/main/scss-rules.js#L27)
	- However, we're not targetting vendor prefixes or using the `ignore` option so we're fine
- **[`*-no-vendor-prefix` rules require vendor prefixes for their `ignore*` option](https://stylelint.io/migration-guide/to-17/#changed--no-vendor-prefix-rules-to-have-consistent-behaviour-for-their-ignore--secondary-options)
	- 	`stylelint-config-standard` [configures `values-no-vendor-prefix` with the `ignoreValues` option](https://github.com/stylelint/stylelint-config-standard/blob/main/index.js#L125-L130)
		- However, we [disable it in our CSS](https://github.com/alphagov/stylelint-config-gds/blob/daf078e4235a107d6b3d03bff0079572ea88dbe1/css-rules.js#L148) rules due to a lack of consistent use of autoprefixer

## `stylelint-config-standard` and `stylelint-config-recommended` rule changes

stylelint-config-standard jumps from 36 to 40. Under the hood, `stylelint-config-recommended` jumps from 14 to 18.

### `stylelint-config-standard` rule changes

- No custom rules in [40.0.0](https://github.com/stylelint/stylelint-config-standard/releases/tag/40.0.0)
- [39.0.0](https://github.com/stylelint/stylelint-config-standard/releases/tag/39.0.0) added 
	- [`block-no-redundant-nested-style-rules`](https://stylelint.io/user-guide/rules/block-no-redundant-nested-style-rules/)
- [38.0.0](https://github.com/stylelint/stylelint-config-standard/releases/tag/38.0.0) added
	- [color-function-alias-notation: "without-alpha"](https://stylelint.io/user-guide/rules/color-function-alias-notation/) prevent use of `rgba`
		- ⚠️ We'll need to override due to our own browser supports and no guarantee tooling transforms `rgb(... / alpha)` into `rgba()` across all codebases at GDS
	- [container-name-pattern](https://stylelint.io/user-guide/rules/container-name-pattern/) to kebab-case
		- 🤔 We may want to make our `-pattern` rules consistent across the board	
	- [layer-name-pattern](https://stylelint.io/user-guide/rules/layer-name-pattern/) to kebab-case
		- 🤔 We may want to make our `-pattern` rules consistent across the board
- No custom rules in [37.0.0](https://github.com/stylelint/stylelint-config-standard/releases/tag/39.0.0)

### `stylelint-config-recommended` rule changes

- No rule changes in [18.0.0](https://github.com/stylelint/stylelint-config-recommended/releases/tag/18.0.0)
- [17.0.0](https://github.com/stylelint/stylelint-config-recommended/releases/tag/17.0.0) added:
	- [`media-type-no-deprecated`](https://stylelint.io/user-guide/rules/media-type-no-deprecated/)
	- [`nesting-selector-no-missing-scoping-root`](https://stylelint.io/user-guide/rules/nesting-selector-no-missing-scoping-root/)
	- [`no-invalid-position-declaration`](https://stylelint.io/user-guide/rules/no-invalid-position-declaration/)
	- [`property-no-deprecated`](https://stylelint.io/user-guide/rules/property-no-deprecated/)
		-  🤔 Need do decide what we do with that one, as [GOV.UK Frontend uses `word-wrap`](https://github.com/alphagov/govuk-frontend/blob/677802b22aec09833f9a8d206a653c787d19f227/packages/govuk-frontend/src/govuk/components/panel/_index.scss#L33) for ex.
- [16.0.0](https://github.com/stylelint/stylelint-config-recommended/releases/tag/16.0.0) added:
	- [`syntax-string-no-invalid`](https://stylelint.io/user-guide/rules/syntax-string-no-invalid/)
- [15.0.0](https://github.com/stylelint/stylelint-config-recommended/releases/tag/15.0.0):
	- Removed [`color-no-invalid-hex`](https://stylelint.io/user-guide/rules/color-no-invalid-hex/), [`function-linear-gradient-no-nonstandard-direction`](https://stylelint.io/user-guide/rules/function-linear-gradient-no-nonstandard-direction/), [`function-no-unknown`](https://stylelint.io/user-guide/rules/function-no-unknown/),
[`unit-no-unknown`](https://stylelint.io/user-guide/rules/function-no-unknown/)
		- 🤔 Any of those we'd want to keep?
	- Changed `string-no-newline rule` to `{ ignore: ['at-rule-preludes', 'declaration-values'] }`
	- Added:
		- [`at-rule-descriptor-no-unknown`](https://stylelint.io/user-guide/rules/at-rule-descriptor-no-unknown/)
		- [`at-rule-descriptor-value-no-unknown`](https://stylelint.io/user-guide/rules/at-rule-descriptor-value-no-unknown/)
		- [`at-rule-no-deprecated`](https://stylelint.io/user-guide/rules/at-rule-no-deprecated/)
		- [`declaration-property-value-keyword-no-deprecated`](https://stylelint.io/user-guide/rules/declaration-property-value-keyword-no-deprecated/)
		- [`declaration-property-value-no-unknown`](https://stylelint.io/user-guide/rules/declaration-property-value-no-unknown/)
		- [`media-feature-name-value-no-unknown`](https://stylelint.io/user-guide/rules/media-feature-name-value-no-unknown/)

## `stylelint-config-standard-scss` and `stylelint-config-recommended-scss` breaking changes

`stylelint-config-standard-scss` gets updated from 13 to 17. Under the hood, `stylelint-config-recommended-scss` jumps from 14 to 17.

### `stylelint-config-standard-scss` changes

- No own rule changes in [17.0.0](https://github.com/stylelint-scss/stylelint-config-standard-scss/releases/tag/v17.0.0)
- No own rule changes in [16.0.0](https://github.com/stylelint-scss/stylelint-config-standard-scss/releases/tag/v16.0.0)
- No own rule changes in [15.0.0](https://github.com/stylelint-scss/stylelint-config-standard-scss/releases/tag/v15.0.0)
	- Besides a fix to `length-zero-no-unit`
- No own rule changes in [14.0.0](https://github.com/stylelint-scss/stylelint-config-standard-scss/releases/tag/v14.0.0)

### `stylelint-config-recommended-scss` changes

- [17.0.0](https://github.com/stylelint-scss/stylelint-config-recommended-scss/releases/tag/v17.0.0) removes
	- [`no-descending-specificity`](https://stylelint.io/user-guide/rules/no-descending-specificity/)
	- [`no-duplicate-selectors`](https://stylelint.io/user-guide/rules/no-duplicate-selectors/)
- No own rule changes in [16.0.0](https://github.com/stylelint-scss/stylelint-config-recommended-scss/releases/tag/v16.0.0)
- No own rule changes in [15.0.0](https://github.com/stylelint-scss/stylelint-config-recommended-scss/releases/tag/v15.0.0)
- No own rule changes in [14.0.0](https://github.com/stylelint-scss/stylelint-config-recommended-scss/releases/tag/v14.0.0)

## Useful links

- [our Scss rules](https://github.com/alphagov/stylelint-config-gds/blob/main/scss-rules.js#L27)
- [our CSS rules](https://github.com/alphagov/stylelint-config-gds/blob/main/css-rules.js#L68)
- [stylelint-config-standard-scss rules](https://github.com/stylelint-scss/stylelint-config-standard-scss/blob/main/index.js)
	- underlying [stylelint-config-recommended-scss rules](https://github.com/stylelint-scss/stylelint-config-recommended-scss/blob/master/index.js)
- [stylelint-config-standard rules](https://github.com/stylelint/stylelint-config-standard/blob/main/index.js)
	- underlying [stylelint-config-recommended rules](https://github.com/stylelint/stylelint-config-recommended/blob/main/index.js#L35)

[^1]: https://github.com/stylelint/stylelint-config-recommended/releases/tag/18.0.0
[^2]: https://github.com/stylelint-scss/stylelint-config-recommended-scss/releases/tag/v17.0.0