### PR TITLE
Update `selector-class-pattern` for Stylelint 17

### DIFF
--- a/css-rules.js
+++ b/css-rules.js
@@ -102,7 +102,6 @@ module.exports = {
       // a loose interpretation on hyphenated BEM in order to allow BEM
       // style and govuk-! overrides
       /^[a-z]([a-z0-9-_!])*$/, {
-        resolveNestedSelectors: true,
         message: 'Class names may only contain [a-z0-9-_!] characters and ' +
           'must start with [a-z]'
       }

--- a/scss-rules.js
+++ b/scss-rules.js
@@ -85,6 +85,16 @@ module.exports = {
         message: 'Placeholders may only contain [a-z0-9-] characters'
       }
     ],
+    // Use the scss version of the rule which accounts for nesting
+    'selector-class-pattern': null,
+    'scss/selector-class-pattern': [
+      // a loose interpretation on hyphenated BEM in order to allow BEM
+      // style and govuk-! overrides
+      /^[a-z]([a-z0-9-_!])*$/, {
+        message: 'Class names may only contain [a-z0-9-_!] characters and ' +
+          'must start with [a-z]'
+      }
+    ],
     // Disable @import needing to be first declarations
     // @import has a different usage in SCSS to CSS and may be scoped or follow SCSS conditionals
     // https://stylelint.io/user-guide/rules/no-invalid-position-at-import-rule/

--- a/test/__snapshots__/css.test.mjs.snap
+++ b/test/__snapshots__/css.test.mjs.snap
@@ -283,7 +283,6 @@ exports[`CSS rules matches snapshots 1`] = `
       /\\^\\[a-z\\]\\(\\[a-z0-9-_!\\]\\)\\*\\$/,
       {
         "message": "Class names may only contain [a-z0-9-_!] characters and must start with [a-z]",
-        "resolveNestedSelectors": true,
       },
     ],
     "selector-id-pattern": [

--- a/test/__snapshots__/scss.test.mjs.snap
+++ b/test/__snapshots__/scss.test.mjs.snap
@@ -471,7 +471,6 @@ exports[`Scss rules matches snapshots 1`] = `
       /\\^\\[a-z\\]\\(\\[a-z0-9-_!\\]\\)\\*\\$/,
       {
         "message": "Class names may only contain [a-z0-9-_!] characters and must start with [a-z]",
-        "resolveNestedSelectors": true,
       },
     ],
     "selector-id-pattern": [

--- a/test/__snapshots__/scss.test.mjs.snap
+++ b/test/__snapshots__/scss.test.mjs.snap
@@ -461,18 +461,19 @@ exports[`Scss rules matches snapshots 1`] = `
         "message": "Placeholders may only contain [a-z0-9-] characters",
       },
     ],
+    "scss/selector-class-pattern": [
+      /\\^\\[a-z\\]\\(\\[a-z0-9-_!\\]\\)\\*\\$/,
+      {
+        "message": "Class names may only contain [a-z0-9-_!] characters and must start with [a-z]",
+      },
+    ],
     "selector-anb-no-unmatchable": [
       true,
     ],
     "selector-attribute-quotes": [
       "always",
     ],
-    "selector-class-pattern": [
-      /\\^\\[a-z\\]\\(\\[a-z0-9-_!\\]\\)\\*\\$/,
-      {
-        "message": "Class names may only contain [a-z0-9-_!] characters and must start with [a-z]",
-      },
-    ],
+    "selector-class-pattern": null,
     "selector-id-pattern": [
       /\\^\\[a-z\\]\\(\\[a-z0-9-\\]\\)\\*\\$/,
       {


### PR DESCRIPTION
Remove the `resolveNestedSelectors` which no longer exists from the CSS rule in the CSS config, and replace the rule with it SCSS version in the SCSS config.

See https://stylelint.io/migration-guide/to-17/#removed-resolvenestedselectors-option-from-selector-class-pattern